### PR TITLE
Port broker to asyncio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - "3.6"
+
+sudo: false
+
+cache: pip
+
+install:
+  - pip install -U pip setuptools wheel
+  - pip install -r dev.txt -r requirements.txt
+
+script:
+  - py.test --cov=. tinyauth
+  - flake8 tinyauth
+
+after_success:
+  - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ cache: pip
 
 install:
   - pip install -U pip setuptools wheel
-  - pip install -r dev.txt -r requirements.txt
+  - pip install -r requirements.txt
 
 script:
-  - py.test --cov=. tinyauth
-  - flake8 tinyauth
+  - py.test --cov=. hpfeeds
+  - flake8 hpfeeds
 
 after_success:
   - codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  ignore:
+  - setup.py

--- a/dev.txt
+++ b/dev.txt
@@ -1,9 +1,0 @@
-attrs==17.3.0
-flake8==3.5.0
-mccabe==0.6.1
-pluggy==0.6.0
-py==1.5.2
-pycodestyle==2.3.1
-pyflakes==1.6.0
-pytest==3.3.1
-six==1.11.0

--- a/hpfeeds/broker/auth/memory.py
+++ b/hpfeeds/broker/auth/memory.py
@@ -1,0 +1,30 @@
+class Authenticator(object):
+
+    '''
+    Authentication class that takes a mapping of user identities and
+    their permissions.
+
+    authenticator = Authenticator({
+        'ident1': {
+            'secret': 'somesecret',
+            'pubchans': ['channel1'],
+            'subchans': ['channel2'],
+            'owner': 'youruser',
+        }
+    })
+    '''
+
+    def __init__(self, creds):
+        self.creds = creds
+
+    def close(self):
+        pass
+
+    def get_authkey(self, ident):
+        authkey = self.creds.get(ident, None)
+        if not authkey:
+            return
+
+        authkey = dict(authkey)
+        authkey['ident'] = ident
+        return authkey

--- a/hpfeeds/broker/auth/sqlite.py
+++ b/hpfeeds/broker/auth/sqlite.py
@@ -1,6 +1,3 @@
-#!/usr/bin/python
-# -*- coding: utf8 -*-
-
 import json
 import sqlite3
 

--- a/hpfeeds/broker/connection.py
+++ b/hpfeeds/broker/connection.py
@@ -55,7 +55,9 @@ class Connection(object):
         self.ak = None
         self.pubchans = []
         self.subchans = []
+
         self.active = True
+
         self.send_queue = asyncio.Queue()
         self.unpacker = Unpacker()
         self.authrand = os.urandom(4)

--- a/hpfeeds/broker/connection.py
+++ b/hpfeeds/broker/connection.py
@@ -23,14 +23,30 @@ from hpfeeds.protocol import (
 )
 
 
-log = logging.getLogger("hpfeeds.connection")
+log = logging.getLogger('hpfeeds.connection')
+
+
+class HpfeedsReader(object):
+
+    def __init__(self, reader):
+        self.reader = reader
+        self.unpacker = Unpacker()
+
+    async def read_message(self):
+        while not self.unpacker.ready():
+            data = await self.reader.read(BUFSIZ)
+            if not data:
+                raise Disconnect('Reader has disconnected')
+            self.unpacker.feed(data)
+
+        return self.unpacker.pop()
 
 
 class Connection(object):
 
     def __init__(self, server, reader, writer):
         self.server = server
-        self.reader = reader
+        self.reader = HpfeedsReader(reader)
         self.writer = writer
 
         self.active_subscriptions = set()
@@ -46,82 +62,92 @@ class Connection(object):
 
     def __str__(self):
         peer, port = self.writer.get_extra_info('peername')
-        return f'<Connection ident={self.ak} owner={self.uid} peer={peer} port={port}'
+        ident = self.ak
+        owner = self.uid
+        return (
+            f'<Connection ident={ident} owner={owner} peer={peer} port={port}'
+        )
 
     async def write(self, message):
-        await self.send_queue.put(message)
+        if self.active:
+            await self.send_queue.put(message)
 
-    async def process_send_queue(self):
-        while self.active:
+    async def publish(self, ident, chan, payload):
+        await self.write(msgpublish(ident, chan, payload))
+
+    async def error(self, error):
+        await self.write(msgerror(error))
+
+    async def _process_send_queue(self):
+        while self.active or not self.send_queue.empty():
             try:
-                self.writer.write(await self.send_queue.get())
+                payload = await self.send_queue.get()
+                self.writer.write(payload)
             except Exception as e:
                 self.active = False
-                writer.close()
+                self.writer.close()
                 raise
 
-        self.writer.write(msgerror('Connection closed'))
         await self.writer.drain()
-        writer.close()
+        self.writer.close()
 
     async def process_publish(self, ident, chan, payload):
         if not ident == self.ak:
             raise BadClient(f"Invalid authkey in message, ident={ident}")
 
         if chan not in self.pubchans:
-            raise BadClient(f"Authkey not allowed to publish here. ident={ident}, chan={chan}")
+            raise BadClient(
+                f'Authkey not allowed to pub here. ident={ident}, chan={chan}'
+            )
 
         await self.server.publish(self, chan, payload)
 
     async def process_subscribe(self, ident, chan):
         if chan not in self.subchans:
-            raise BadClient(f"Authkey not allowed to subscribe here. ident={ident}, chan={chan}")
+            raise BadClient(
+                f'Authkey not allowed to sub here. ident={ident}, chan={chan}'
+            )
 
         await self.server.do_subscribe(self, ident, chan)
 
     async def process_unsubscribe(self, ident, chan):
         await self.server.do_unsubscribe(self, ident, chan)
 
-    async def process_incoming(self):
-        while self.active:
-            data = await self.reader.read(BUFSIZ)
-            if not data:
-                self.active = False
-                break
+    async def process_incoming_single(self):
+        opcode, data = await self.reader.read_message()
+        if opcode == OP_PUBLISH:
+            await self.process_publish(*readpublish(data))
+        elif opcode == OP_SUBSCRIBE:
+            await self.process_subscribe(*readsubscribe(data))
+        elif opcode == OP_UNSUBSCRIBE:
+            await self.process_unsubscribe(*readsubscribe(data))
+        else:
+            raise BadClient((
+                'Known opcode at unexpected moment '
+                '(opcode={opcode}, len={data_length})'
+            ))
 
-            self.unpacker.feed(data)
+    async def _process_incoming(self):
+        try:
+            opcode, data = await self.reader.read_message()
+            if opcode != OP_AUTH:
+                raise BadClient('First message was not AUTH')
 
-            for opcode, data in self.unpacker:
-                if opcode != OP_AUTH:
-                    raise BadClient('First message was not AUTH.')
-                ident, rhash = readauth(data)
-                self.authkey_check(ident, rhash)
-                break
+            self.authkey_check(*readauth(data))
 
-        while self.active:
-            data = await self.reader.read(BUFSIZ)
-            if not data:
-                self.active = False
-                break
+            while self.active:
+                await self.process_incoming_single()
 
-            self.unpacker.feed(data)
-
-            for opcode, data in self.unpacker:
-                if opcode == OP_PUBLISH:
-                    await self.process_publish(*readpublish(data))
-                elif opcode == OP_SUBSCRIBE:
-                    await self.process_subscribe(*readsubscribe(data))
-                elif opcode == OP_UNSUBSCRIBE:
-                    await self.process_unsubscribe(*readsubscribe(data))
-                else:
-                    raise BadClient('Unknown message type (opcode={opcode}, len={data_length})')
+        except BadClient as e:
+            await self.write(msgerror(str(e)))
+            self.active = False
 
     async def handle(self):
         self.writer.write(msginfo(self.server.name, self.authrand))
 
         process_tasks = asyncio.gather(
-            self.process_send_queue(),
-            self.process_incoming(),
+            self._process_send_queue(),
+            self._process_incoming(),
             )
 
         try:
@@ -129,7 +155,7 @@ class Connection(object):
         except asyncio.CancelledError:
             self.active = False
             await process_tasks
-            #await process_tasks.cancel()
+            # await process_tasks.cancel()
 
         self.active = False
 

--- a/hpfeeds/broker/connection.py
+++ b/hpfeeds/broker/connection.py
@@ -111,7 +111,7 @@ class Connection(object):
     async def _process_subscribe(self, ident, chan):
         if chan not in self.subchans:
             raise BadClient(
-                f'Authkey not allowed to sub here. ident={self.ident}, chan={chan}'
+                f'Authkey not allowed to sub here. ident={self.ak}, chan={chan}'
             )
 
         await self.server.subscribe(self, chan)

--- a/hpfeeds/broker/connection.py
+++ b/hpfeeds/broker/connection.py
@@ -2,26 +2,25 @@
 # -*- coding: utf8 -*-
 
 import asyncio
-import os
 import logging
+import os
 
 from hpfeeds.exceptions import BadClient, Disconnect, ProtocolException
 from hpfeeds.protocol import (
     BUFSIZ,
     OP_AUTH,
+    OP_PUBLISH,
     OP_SUBSCRIBE,
     OP_UNSUBSCRIBE,
-    OP_PUBLISH,
+    Unpacker,
+    hashsecret,
     msgerror,
     msginfo,
     msgpublish,
-    readsubscribe,
-    readpublish,
     readauth,
-    hashsecret,
-    Unpacker,
+    readpublish,
+    readsubscribe,
 )
-
 
 log = logging.getLogger('hpfeeds.connection')
 

--- a/hpfeeds/broker/connection.py
+++ b/hpfeeds/broker/connection.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+# -*- coding: utf8 -*-
+
+import asyncio
+import os
+import logging
+
+from hpfeeds.exceptions import BadClient, Disconnect
+from hpfeeds.protocol import (
+    BUFSIZ,
+    OP_AUTH,
+    OP_SUBSCRIBE,
+    OP_UNSUBSCRIBE,
+    OP_PUBLISH,
+    msgerror,
+    msginfo,
+    msgpublish,
+    readsubscribe,
+    readpublish,
+    readauth,
+    hashsecret,
+    Unpacker,
+)
+
+
+log = logging.getLogger("hpfeeds.connection")
+
+
+class Connection(object):
+
+    def __init__(self, server, reader, writer):
+        self.server = server
+        self.reader = reader
+        self.writer = writer
+
+        self.active_subscriptions = set()
+
+        self.uid = None
+        self.ak = None
+        self.pubchans = []
+        self.subchans = []
+        self.active = True
+        self.send_queue = asyncio.Queue()
+        self.unpacker = Unpacker()
+        self.authrand = os.urandom(4)
+
+    def __str__(self):
+        peer, port = self.writer.get_extra_info('peername')
+        return f'<Connection ident={self.ak} owner={self.uid} peer={peer} port={port}'
+
+    async def write(self, message):
+        await self.send_queue.put(message)
+
+    async def process_send_queue(self):
+        while self.active:
+            try:
+                self.writer.write(await self.send_queue.get())
+            except Exception as e:
+                self.active = False
+                writer.close()
+                raise
+
+        self.writer.write(msgerror('Connection closed'))
+        await self.writer.drain()
+        writer.close()
+
+    async def process_publish(self, ident, chan, payload):
+        if not ident == self.ak:
+            raise BadClient(f"Invalid authkey in message, ident={ident}")
+
+        if chan not in self.pubchans:
+            raise BadClient(f"Authkey not allowed to publish here. ident={ident}, chan={chan}")
+
+        await self.server.publish(self, chan, payload)
+
+    async def process_subscribe(self, ident, chan):
+        if chan not in self.subchans:
+            raise BadClient(f"Authkey not allowed to subscribe here. ident={ident}, chan={chan}")
+
+        await self.server.do_subscribe(self, ident, chan)
+
+    async def process_unsubscribe(self, ident, chan):
+        await self.server.do_unsubscribe(self, ident, chan)
+
+    async def process_incoming(self):
+        while self.active:
+            data = await self.reader.read(BUFSIZ)
+            if not data:
+                self.active = False
+                break
+
+            self.unpacker.feed(data)
+
+            for opcode, data in self.unpacker:
+                if opcode != OP_AUTH:
+                    raise BadClient('First message was not AUTH.')
+                ident, rhash = readauth(data)
+                self.authkey_check(ident, rhash)
+                break
+
+        while self.active:
+            data = await self.reader.read(BUFSIZ)
+            if not data:
+                self.active = False
+                break
+
+            self.unpacker.feed(data)
+
+            for opcode, data in self.unpacker:
+                if opcode == OP_PUBLISH:
+                    await self.process_publish(*readpublish(data))
+                elif opcode == OP_SUBSCRIBE:
+                    await self.process_subscribe(*readsubscribe(data))
+                elif opcode == OP_UNSUBSCRIBE:
+                    await self.process_unsubscribe(*readsubscribe(data))
+                else:
+                    raise BadClient('Unknown message type (opcode={opcode}, len={data_length})')
+
+    async def handle(self):
+        self.writer.write(msginfo(self.server.name, self.authrand))
+
+        process_tasks = asyncio.gather(
+            self.process_send_queue(),
+            self.process_incoming(),
+            )
+
+        try:
+            await process_tasks
+        except asyncio.CancelledError:
+            self.active = False
+            await process_tasks
+            #await process_tasks.cancel()
+
+        self.active = False
+
+    def authkey_check(self, ident, rhash):
+        akrow = self.server.get_authkey(ident)
+        if not akrow:
+            raise BadClient(f"Authentication failed for {ident}")
+
+        akhash = hashsecret(self.authrand, akrow["secret"])
+        if not akhash == rhash:
+            raise BadClient(f"Authentication failed for {ident}")
+
+        self.ak = ident
+        self.uid = akrow["owner"]
+        self.pubchans = akrow.get("pubchans", [])
+        self.subchans = akrow.get("subchans", [])

--- a/hpfeeds/broker/connection.py
+++ b/hpfeeds/broker/connection.py
@@ -105,13 +105,13 @@ class Connection(object):
     async def process_subscribe(self, ident, chan):
         if chan not in self.subchans:
             raise BadClient(
-                f'Authkey not allowed to sub here. ident={ident}, chan={chan}'
+                f'Authkey not allowed to sub here. ident={self.ident}, chan={chan}'
             )
 
-        await self.server.do_subscribe(self, ident, chan)
+        await self.server.subscribe(self, chan)
 
     async def process_unsubscribe(self, ident, chan):
-        await self.server.do_unsubscribe(self, ident, chan)
+        await self.server.unsubscribe(self, chan)
 
     async def _process_incoming_single(self):
         opcode, data = await self.reader.read_message()

--- a/hpfeeds/broker/prometheus.py
+++ b/hpfeeds/broker/prometheus.py
@@ -1,6 +1,5 @@
 from prometheus_client import Counter, Gauge, Histogram
 
-
 CLIENT_CONNECTIONS = Gauge(
     'hpfeeds_broker_client_connections',
     'Number of clients connected to broker',

--- a/hpfeeds/broker/prometheus.py
+++ b/hpfeeds/broker/prometheus.py
@@ -1,0 +1,25 @@
+from prometheus_client import Counter, Gauge, Histogram
+
+
+CLIENT_CONNECTIONS = Gauge(
+    'hpfeeds_broker_client_connections',
+    'Number of clients connected to broker',
+)
+
+SUBSCRIPTIONS = Gauge(
+    'hpfeeds_broker_subscriptions',
+    'Number of subscriptions to a channel',
+    ['ident', 'chan'],
+)
+
+RECEIVE_PUBLISH_COUNT = Counter(
+    'hpfeeds_broker_receive_publish_count',
+    'Number of events received by broker for a channel',
+    ['ident', 'chan'],
+)
+
+RECEIVE_PUBLISH_SIZE = Histogram(
+    'hpfeeds_broker_receive_publish_size',
+    'Sizes of messages received by broker for a channel',
+    ['ident', 'chan'],
+)

--- a/hpfeeds/broker/server.py
+++ b/hpfeeds/broker/server.py
@@ -20,11 +20,12 @@ log = logging.getLogger("hpfeeds.broker")
 
 class Server(object):
 
-    def __init__(self, auth, address='127.0.0.1', port=20000, name='hpfeeds'):
+    def __init__(self, auth, address=None, port=None, sock=None, name='hpfeeds'):
         self.auth = auth
         self.name = name
         self.bind_address = address
         self.bind_port = port
+        self.sock = sock
 
         self.connections = set()
         self.subscriptions = collections.defaultdict(list)
@@ -93,7 +94,8 @@ class Server(object):
         server = await asyncio.start_server(
             self._handle_connection,
             self.bind_address,
-            self.bind_port
+            self.bind_port,
+            sock=self.sock,
         )
 
         try:

--- a/hpfeeds/broker/server.py
+++ b/hpfeeds/broker/server.py
@@ -52,7 +52,7 @@ class Server(object):
                     log.warn(f'Connection ended; bad client: {connection}')
         finally:
             for chan in list(connection.active_subscriptions):
-                self.unsubscribe(connection, chan)
+                await self.unsubscribe(connection, chan)
 
             if connection in self.connections:
                 self.connections.remove(connection)
@@ -76,7 +76,7 @@ class Server(object):
         '''
         Subscribe a connection to a channel
         '''
-        SUBSCRIPTIONS.labels(source.ac, chan).inc()
+        SUBSCRIPTIONS.labels(source.ak, chan).inc()
         self.subscriptions[chan].append(source)
         source.active_subscriptions.add(chan)
 
@@ -86,9 +86,9 @@ class Server(object):
         '''
         if chan in source.active_subscriptions:
             source.active_subscriptions.remove(chan)
-        if source in self.subsciptions[chan]:
-            self.subsciptions[chan].remove(source)
-        SUBSCRIPTIONS.labels(source.ac, chan).dec()
+        if source in self.subscriptions[chan]:
+            self.subscriptions[chan].remove(source)
+        SUBSCRIPTIONS.labels(source.ak, chan).dec()
 
     async def serve_forever(self):
         ''' Start handling connections. Await on this to listen forever. '''

--- a/hpfeeds/broker/server.py
+++ b/hpfeeds/broker/server.py
@@ -5,17 +5,15 @@ import asyncio
 import collections
 import logging
 
-
 from hpfeeds.exceptions import BadClient, Disconnect
 
 from .connection import Connection
 from .prometheus import (
     CLIENT_CONNECTIONS,
-    SUBSCRIPTIONS,
     RECEIVE_PUBLISH_COUNT,
     RECEIVE_PUBLISH_SIZE,
+    SUBSCRIPTIONS,
 )
-
 
 log = logging.getLogger("hpfeeds.broker")
 

--- a/hpfeeds/broker/server.py
+++ b/hpfeeds/broker/server.py
@@ -101,4 +101,13 @@ class Server(object):
                 await asyncio.sleep(10)
         except asyncio.CancelledError:
             server.close()
+
+            for connection in list(self.connections):
+                connection.active = False
+
+            for connection in list(self.connections):
+                log.debug(f'Waiting for {connection} to wrap up')
+                await connection.wait_closed()
+
+            log.debug(f'Waiting for {self} to wrap up')
             await server.wait_closed()

--- a/hpfeeds/broker/server.py
+++ b/hpfeeds/broker/server.py
@@ -102,12 +102,11 @@ class Server(object):
         except asyncio.CancelledError:
             server.close()
 
-            for connection in list(self.connections):
-                connection.active = False
-
-            for connection in list(self.connections):
-                log.debug(f'Waiting for {connection} to wrap up')
-                await connection.wait_closed()
+            for future in asyncio.as_completed([c.close() for c in list(self.connections)]):
+                try:
+                    await future
+                except Exception as e:
+                    log.exception(e)
 
             log.debug(f'Waiting for {self} to wrap up')
             await server.wait_closed()

--- a/hpfeeds/broker/server.py
+++ b/hpfeeds/broker/server.py
@@ -1,258 +1,101 @@
 #!/usr/bin/python
 # -*- coding: utf8 -*-
 
-import gevent.monkey
-gevent.monkey.patch_all()  # noqa: E402
-
+import asyncio
 import collections
-import os
 import logging
 
-import gevent
-import gevent.server
 
-from hpfeeds.broker.auth import sqlite
 from hpfeeds.exceptions import BadClient, Disconnect
-from hpfeeds.protocol import (
-    BUFSIZ,
-    OP_AUTH,
-    OP_SUBSCRIBE,
-    OP_UNSUBSCRIBE,
-    OP_PUBLISH,
-    msgerror,
-    msginfo,
-    msgpublish,
-    readsubscribe,
-    readpublish,
-    readauth,
-    hashsecret,
-    Unpacker,
+
+from .connection import Connection
+from .prometheus import (
+    CLIENT_CONNECTIONS,
+    SUBSCRIPTIONS,
+    RECEIVE_PUBLISH_COUNT,
+    RECEIVE_PUBLISH_SIZE,
 )
 
 
-log = logging.getLogger("broker")
-
-
-class Connection(object):
-
-    def __init__(self, sock, addr, srv):
-        self.sock = sock
-        self.addr = addr
-        self.srv = srv
-        self.uid = None
-        self.ak = None
-        self.pubchans = []
-        self.subchans = []
-        self.active = True
-        self.unpacker = Unpacker()
-
-    def __del__(self):
-        # if this message is not showing up we're leaking references
-        log.debug("Connection cleanup {0}".format(self.addr))
-
-    def write(self, data):
-        try:
-            self.sock.sendall(data)
-            #  self.stats['bytes_sent'] += len(data)
-        except Exception as e:
-            log.critical('Exception when writing to conn', exc_info=e)
-
-    def handle(self):
-        # first send the info message
-        self.authrand = authrand = os.urandom(4)
-        self.write(msginfo(config.FBNAME, authrand))
-
-        while True:
-            self.unpacker.feed(self.s.recv(BUFSIZ))
-            for opcode, data in self.unpacker:
-                if opcode != OP_AUTH:
-                    self.error('First message was not AUTH.')
-                    raise BadClient()
-
-                ident, rhash = readauth(data)
-                self.authkey_check(ident, rhash)
-                break
-
-        while True:
-            self.unpacker.feed(self.recv(BUFSIZ))
-
-            for opcode, data in self.unpacker:
-                if opcode == OP_PUBLISH:
-                    self.do_publish(*readpublish(data))
-                elif opcode == OP_SUBSCRIBE:
-                    self.do_subscribe(*readsubscribe(data))
-                elif opcode == OP_UNSUBSCRIBE:
-                    self.do_unsubscribe(*readsubscribe(data))
-                else:
-                    self.error(
-                        "Unknown message type.",
-                        opcode=opcode,
-                        length=len(data),
-                    )
-                    raise BadClient()
-
-    def do_publish(self, ident, chan, payload):
-        if not ident == self.ak:
-            self.error("Invalid authkey in message.", ident=ident)
-            raise BadClient()
-
-        if chan not in self.pubchans or chan.endswith("..broker"):
-            self.error(
-                "Authkey not allowed to publish here.",
-                chan=chan
-            )
-            return
-
-        self.srv.do_publish(self, chan, payload)
-        #  self.stats["published"] += 1
-
-    def do_subscribe(self, ident, chan):
-        checkchan = chan
-        if chan.endswith('..broker'):
-            checkchan = chan.rsplit('..broker', 1)[0]
-
-        if checkchan not in self.subchans:
-            self.error(
-                "Authkey not allowed to subscribe here.",
-                chan=chan,
-            )
-            return
-
-        self.srv.do_subscribe(self, ident, chan)
-
-    def do_unsubscribe(self, ident, chan):
-        self.do_unsubscribe(self, ident, chan)
-
-    def authkey_check(self, ident, rhash):
-        akrow = self.srv.get_authkey(ident)
-        if not akrow:
-            self.error("Authentication failed.", ident=ident)
-            raise BadClient()
-
-        akhash = hashsecret(self.authrand, akrow["secret"])
-        if not akhash == rhash:
-            self.error("Authentication failed.", ident=ident)
-            raise BadClient()
-
-        self.ak = ident
-        self.uid = akrow["owner"]
-        self.pubchans = akrow.get("pubchans", [])
-        self.subchans = akrow.get("subchans", [])
-
-    def forward(self, ident, chan, data):
-        self.write(msgpublish(ident, chan, data))
-        #  self.stats['received'] += 1
-
-    def error(self, msg, *args, **context):
-        emsg = msg.format(*args)
-        log.critical(emsg)
-        self.srv.log_error(emsg, self, context)
-        self.write(msgerror(emsg))
+log = logging.getLogger("hpfeeds.broker")
 
 
 class Server(object):
 
-    def __init__(self):
-        self.listener = gevent.server.StreamServer(
-            (config.FBIP, config.FBPORT),
-            self._newconn,
-            **config.SSLOPTS
-        )
-        self.db = self.dbclass()
+    def __init__(self, auth, bind_address='127.0.0.1', bind_port=20000, name='hpfeeds'):
+        self.auth = auth
+        self.name = name
+        self.bind_address = bind_address
+        self.bind_port = bind_port
+
         self.connections = set()
-        self.subscribermap = collections.defaultdict(list)
-        self.conn2chans = collections.defaultdict(list)
+        self.subscriptions = collections.defaultdict(list)
 
-    def dbclass(self):
-        return sqlite.Authenticator('db.sqlite3')
+    async def _handle_connection(self, reader, writer):
+        '''
+        This is called for each connection to our bound address/port to setup a
+        new Connection object and handle lifecycle management.
+        '''
 
-    def connclass(self, *args):
-        return Connection(*args)
+        connection = Connection(self, reader, writer)
+        self.connections.add(connection)
 
-    def serve_forever(self):
-        log.info("StreamServer ssl_enabled=%s", str(self.listener.ssl_enabled))
-        self.listener.serve_forever()
-
-    def _newconn(self, sock, addr):
-        log.debug('Connection from {0}.'.format(addr))
-        fc = self.connclass(sock, addr, self)
-        self.connections.add(fc)
+        log.debug(f'Connection from {connection}.')
 
         try:
-            fc.handle()
-        except Disconnect:
-            log.debug("Connection closed by {0}".format(addr))
-        except BadClient:
-            log.warn('Connection ended due to bad client: {0}'.format(addr))
+            with CLIENT_CONNECTIONS.track_inprogress():
+                try:
+                    await connection.handle()
+                except Disconnect:
+                    log.debug(f'Connection closed by {connection}')
+                except BadClient:
+                    log.warn(f'Connection ended due to bad client: {connection}')
+        finally:
+            for chan in list(connection.active_subscriptions):
+                self.unsubscribe(connection, chan)
 
-        fc.active = False
+            if connection in self.connections:
+                self.connections.remove(connection)
 
-        for chan in self.conn2chans[fc]:
-            self.subscribermap[chan].remove(fc)
-            if fc.ak:
-                self._brokerchan(fc, chan, fc.ak, 'leave')
-
-        del self.conn2chans[fc]
-
-        self.connections.remove(fc)
-        try:
-            sock.close()
-        except Exception:
-            pass
-
-    def do_publish(self, c, chan, data):
-        log.debug('publish to {0} by {1} ak {2} addr {3}'.format(
-            chan, c.uid, c.ak, c.addr
-        ))
-        try:
-            for c2 in self.receivers(chan, c, self.subscribermap[chan]):
-                c2.forward(c.ak, chan, data)
-        except Exception as e:
-            log.exception('Error publishing payload')
-
-    def do_subscribe(self, c, ident, chan):
-        log.debug('broker subscribe to {0} by {1}@{2}'.format(
-            chan, ident, c.addr
-        ))
-        self.subscribermap[chan].append(c)
-        self.conn2chans[c].append(chan)
-        if not chan.endswith('..broker'):
-            self._brokerchan(c, chan, ident, 'join')
-
-    def do_unsubscribe(self, c, ident, chan):
-        log.debug('broker unsubscribe to {0} by {1}@{2}'.format(
-            chan, ident, c.addr
-        ))
-        self.subscribermap[chan].remove(c)
-        self.conn2chans[c].remove(chan)
-        if not chan.endswith('..broker'):
-            self._brokerchan(c, chan, ident, 'leave')
-
-    def _brokerchan(self, c, chan, ident, data):
-        brokchan = chan + '..broker'
-        try:
-            for c2 in self.receivers(chan, c, self.subscribermap[brokchan]):
-                c2.publish(ident, chan, data)
-        except Exception as e:
-            log.exception('Error publishing to broker channels')
-
-    def log_error(self, emsg, conn, context):
-        return self.db.log({
-            "msg": emsg,
-            "ip": conn.addr[0],
-            "user": conn.uid,
-            "authkey": conn.ak,
-            "context": context,
-        })
+            log.debug(f'Disconnection from {connection}; cleanup completed.')
 
     def get_authkey(self, identifier):
-        return self.db.get_authkey(identifier)
+        return self.auth.get_authkey(identifier)
 
-    def receivers(self, chan, conn, subscribed_conns):
-        if not subscribed_conns:
-            return
+    async def publish(self, source, chan, data):
+        '''
+        Called by a connection to push data to all subscribers of a channel
+        '''
+        RECEIVE_PUBLISH_COUNT.labels(source.ak, chan).inc()
+        RECEIVE_PUBLISH_SIZE.labels(source.ak, chan).observe(len(data))
 
-        # this is plain hpfeeds mode, no graph
-        # all subscribed connections allowed to receive by default
-        for c in subscribed_conns:
-            yield c
+        for dest in self.subscriptions[chan]:
+            await dest.publish(chan, data)
+
+    async def subscribe(self, source, chan):
+        '''
+        Subscribe a connection to a channel
+        '''
+        SUBSCRIPTIONS.labels(source.ac, chan).inc()
+        self.subscriptions[chan].append(source)
+        source.active_subscriptions.add(chan)
+
+    async def unsubscribe(self, source, chan):
+        '''
+        Unsubscribe a connection from a channel
+        '''
+        if chan in source.active_subscriptions:
+            source.active_subscriptions.remove(chan)
+        if source in self.subsciptions[chan]:
+            self.subsciptions[chan].remove(source)
+        SUBSCRIPTIONS.labels(source.ac, chan).dec()
+
+    async def serve_forever(self):
+        ''' Start handling connections. Await on this to listen forever. '''
+        server = await asyncio.start_server(self._handle_connection, self.bind_address, self.bind_port)
+        try:
+            while True:
+                await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            server.close()
+            await server.wait_closed()

--- a/hpfeeds/client.py
+++ b/hpfeeds/client.py
@@ -193,6 +193,15 @@ class Client(object):
 
         logger.info('Stopped, exiting run loop.')
 
+    def _read_message(self):
+        d = self.recv()
+        if not d:
+            raise Disconnect()
+
+        self.unpacker.feed(d)
+        for opcode, data in self.unpacker:
+            return (opcode, data)
+
     def wait(self, timeout=1):
         self.s.settimeout(timeout)
 

--- a/hpfeeds/client.py
+++ b/hpfeeds/client.py
@@ -18,6 +18,7 @@ from .protocol import (
     msgauth,
     msgpublish,
     msgsubscribe,
+    readerror,
     readinfo,
     readpublish,
     Unpacker,
@@ -175,7 +176,7 @@ class Client(object):
                         if opcode == OP_PUBLISH:
                             message_callback(*readpublish(data))
                         elif opcode == OP_ERROR:
-                            error_callback(data)
+                            error_callback(readerror(data))
 
                 except Disconnect as e:
                     self.connected = False
@@ -203,7 +204,7 @@ class Client(object):
             self.unpacker.feed(d)
             for opcode, data in self.unpacker:
                 if opcode == OP_ERROR:
-                    return data
+                    return readerror(data)
         except Disconnect:
             pass
 

--- a/hpfeeds/client.py
+++ b/hpfeeds/client.py
@@ -2,26 +2,26 @@
 # This file is part of hpfeeds - https://github.com/rep/hpfeeds
 # See the file 'LICENSE' for copying permission.
 
-import sys
-import socket
 import logging
-import time
-import threading
+import socket
 import ssl
+import sys
+import threading
+import time
 
-from .exceptions import FeedException, Disconnect
+from .exceptions import Disconnect, FeedException
 from .protocol import (
+    BUFSIZ,
+    OP_ERROR,
     OP_INFO,
     OP_PUBLISH,
-    OP_ERROR,
-    BUFSIZ,
+    Unpacker,
     msgauth,
     msgpublish,
     msgsubscribe,
     readerror,
     readinfo,
     readpublish,
-    Unpacker,
 )
 
 logger = logging.getLogger('pyhpfeeds')

--- a/hpfeeds/exceptions.py
+++ b/hpfeeds/exceptions.py
@@ -1,7 +1,3 @@
-class BadClient(Exception):
-    pass
-
-
 class FeedException(Exception):
     pass
 
@@ -11,4 +7,8 @@ class Disconnect(Exception):
 
 
 class ProtocolException(Disconnect):
+    pass
+
+
+class BadClient(ProtocolException):
     pass

--- a/hpfeeds/protocol.py
+++ b/hpfeeds/protocol.py
@@ -2,11 +2,10 @@
 # This file is part of hpfeeds - https://github.com/rep/hpfeeds
 # See the file 'LICENSE' for copying permission.
 
-import struct
 import hashlib
+import struct
 
 from .exceptions import ProtocolException
-
 
 BUFSIZ = 16384
 

--- a/hpfeeds/protocol.py
+++ b/hpfeeds/protocol.py
@@ -69,6 +69,10 @@ def msgsubscribe(ident, chan):
     return msghdr(OP_SUBSCRIBE, strpack8(ident) + force_bytes(chan))
 
 
+def msgunsubscribe(ident, chan):
+    return msghdr(OP_UNSUBSCRIBE, strpack8(ident) + force_bytes(chan))
+
+
 def msgpublish(ident, chan, data):
     return msghdr(
         OP_PUBLISH,

--- a/hpfeeds/protocol.py
+++ b/hpfeeds/protocol.py
@@ -151,7 +151,7 @@ class Unpacker(object):
 
     def pop(self):
         ml, opcode = struct.unpack('!iB', self.buf[0:5])
-        data = bytearray(self.buf[5:])
+        data = bytes(self.buf[5:][:ml-5])
         del self.buf[:ml]
         return opcode, data
 

--- a/hpfeeds/scripts/broker.py
+++ b/hpfeeds/scripts/broker.py
@@ -21,8 +21,8 @@ def main():
 
     broker = Server(
         auth=sqlite.Authenticator('sqlite.db'),
-        bind_address=args.host,
-        bind_port=args.port,
+        address=args.host,
+        port=args.port,
         name=args.name,
     )
 

--- a/hpfeeds/scripts/broker.py
+++ b/hpfeeds/scripts/broker.py
@@ -1,10 +1,29 @@
+import argparse
 import logging
 
+import aiorun
+
+from hpfeeds.broker.auth import sqlite
 from hpfeeds.broker.server import Server
 
 
 def main():
-    logging.basicConfig(level=logging.DEBUG if config.DEBUG else logging.INFO)
-    s = Server()
-    s.serve_forever()
-    return 0
+    parser = argparse.ArgumentParser(description='Run a hpfeeds broker')
+    parser.add_argument('--host', default='0.0.0.0', action='store')
+    parser.add_argument('--port', default='20000', action='store')
+    parser.add_argument('--name', default='hpfeeds', action='store')
+    parser.add_argument('--debug', default=False, action='store_true')
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.debug else logging.INFO,
+    )
+
+    broker = Server(
+        auth=sqlite.Authenticator('sqlite.db'),
+        bind_address=args.host,
+        bind_port=args.port,
+        name=args.name,
+    )
+
+    return aiorun.run(broker.serve_forever())

--- a/hpfeeds/scripts/cli.py
+++ b/hpfeeds/scripts/cli.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
-import sys
-import optparse
 import logging
+import optparse
 import string
+import sys
 
 import hpfeeds
 

--- a/hpfeeds/tests/test_broker_connection.py
+++ b/hpfeeds/tests/test_broker_connection.py
@@ -1,0 +1,31 @@
+import asyncio
+import unittest
+
+import aiomock
+
+from hpfeeds.broker.connection import Connection
+from hpfeeds.protocol import msgpublish
+
+
+class TestConnection(unittest.TestCase):
+
+    def setUp(self):
+        self.server = aiomock.AIOMock()
+        self.server.name = 'hpfeeds'
+
+        self.reader = aiomock.AIOMock()
+        self.writer = aiomock.AIOMock()
+        self.writer.get_extra_info.return_value = ('127.0.0.1', 65432)
+        self.writer.drain.async_return_value = None
+
+        self.connection = Connection(self.server, self.reader, self.writer)
+
+    def test_sends_challenge(self):
+        asyncio.get_event_loop().run_until_complete(self.connection.handle())
+        assert self.writer.write.call_args[0][0][:-4] == b'\x00\x00\x00\x11\x01\x07hpfeeds'
+
+    def test_must_auth(self):
+        test_message = msgpublish('a', 'b', b'c')
+        self.reader.read.async_return_value = test_message
+        asyncio.get_event_loop().run_until_complete(self.connection.handle())
+        assert self.writer.write.call_args_list[-1][0][0] == b'\x00\x00\x00\x1f\x00First message was not AUTH'

--- a/hpfeeds/tests/test_broker_integration.py
+++ b/hpfeeds/tests/test_broker_integration.py
@@ -1,0 +1,128 @@
+import asyncio
+import unittest
+
+from hpfeeds.broker.auth.memory import Authenticator
+from hpfeeds.broker.connection import HpfeedsReader
+from hpfeeds.broker.server import Server
+from hpfeeds.protocol import msgauth, msgpublish, msgsubscribe, readinfo, readpublish
+
+
+class QueueWriter(object):
+
+    def __init__(self, queue):
+        self.queue = queue
+
+    def get_extra_info(self, key):
+        return ('127.0.0.1', 8080)
+
+    def write(self, data):
+        print(self, 'write', data)
+        self.queue.put_nowait(data)
+
+    async def drain(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class QueueReader(object):
+
+    def __init__(self, queue):
+        self.queue = queue
+        self.buffer = b''
+
+    async def read(self, amt):
+        if not self.buffer:
+            self.buffer = await self.queue.get()
+
+        buffer, self.buffer = self.buffer[:amt], self.buffer[amt:]
+
+        print(self, 'read', amt, buffer)
+
+        return buffer
+
+    def close(self):
+        pass
+
+
+def setup_pipe():
+    queue = asyncio.Queue()
+    reader = QueueReader(queue)
+    writer = QueueWriter(queue)
+    return reader, writer
+
+
+class TestBrokerIntegration(unittest.TestCase):
+
+    def setUp(self):
+        authenticator = Authenticator({
+            'test': {
+                'secret': 'secret',
+                'subchans': ['test-chan'],
+                'pubchans': ['test-chan'],
+                'owner': 'some-owner',
+            }
+        })
+
+        self.server = Server(authenticator, address='127.0.0.1', port=20000)
+
+        self.client_reader, self.server_writer = setup_pipe()
+        self.server_reader, self.client_writer = setup_pipe()
+
+        self.client_reader = HpfeedsReader(self.client_reader)
+
+    def test_sends_challenge(self):
+        async def inner():
+            self.client_writer.write(b'')
+            await self.server._handle_connection(self.server_reader, self.server_writer)
+            data = await self.client_reader.read_message()
+            assert data[1][:-4] == b'\x07hpfeeds'
+        asyncio.get_event_loop().run_until_complete(inner())
+
+    def test_must_auth(self):
+        async def inner():
+            test_message = msgpublish('a', 'b', b'c')
+            self.client_writer.write(test_message)
+            self.client_writer.write(b'')
+
+            await self.server._handle_connection(self.server_reader, self.server_writer)
+
+            # Ignore challenge
+            op, data = await self.client_reader.read_message()
+            assert op == 1
+
+            # Should be an error message
+            op, data = await self.client_reader.read_message()
+            assert op == 0
+            assert data == b'First message was not AUTH'
+
+        asyncio.get_event_loop().run_until_complete(inner())
+
+    def test_auth_success(self):
+        async def inner():
+            connection = asyncio.ensure_future(
+                self.server._handle_connection(self.server_reader, self.server_writer)
+            )
+
+            op, data = await self.client_reader.read_message()
+            assert op == 1
+            name, rand = readinfo(data)
+
+            self.client_writer.write(msgauth(rand, 'test', 'secret'))
+            self.client_writer.write(msgsubscribe('test', 'test-chan'))
+            self.client_writer.write(msgpublish('test', 'test-chan', b'c'))
+            self.client_writer.write(b'')
+
+            await connection
+
+            # Should be a publish event
+            op, data = await self.client_reader.read_message()
+            assert op == 3
+            assert readpublish(data) == (
+                'test',
+                'test-chan',
+                b'c'
+            )
+
+        asyncio.get_event_loop().run_until_complete(inner())

--- a/hpfeeds/tests/test_broker_integration.py
+++ b/hpfeeds/tests/test_broker_integration.py
@@ -4,7 +4,15 @@ import unittest
 from hpfeeds.broker.auth.memory import Authenticator
 from hpfeeds.broker.connection import HpfeedsReader
 from hpfeeds.broker.server import Server
-from hpfeeds.protocol import msgauth, msgpublish, msgsubscribe, msgunsubscribe, readerror, readinfo, readpublish
+from hpfeeds.protocol import (
+    msgauth,
+    msgpublish,
+    msgsubscribe,
+    msgunsubscribe,
+    readerror,
+    readinfo,
+    readpublish,
+)
 
 
 class QueueWriter(object):

--- a/hpfeeds/tests/test_client_integration.py
+++ b/hpfeeds/tests/test_client_integration.py
@@ -3,9 +3,9 @@ import logging
 import threading
 import unittest
 
+from hpfeeds import client
 from hpfeeds.broker.auth.memory import Authenticator
 from hpfeeds.broker.server import Server
-from hpfeeds import client
 from hpfeeds.protocol import readpublish
 
 

--- a/hpfeeds/tests/test_client_integration.py
+++ b/hpfeeds/tests/test_client_integration.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+import threading
+import unittest
+
+from hpfeeds.broker.auth.memory import Authenticator
+from hpfeeds.broker.server import Server
+from hpfeeds.client import Client
+from hpfeeds.protocol import readpublish
+
+
+class TestClientIntegration(unittest.TestCase):
+
+    log = logging.getLogger('hpfeeds.testserver')
+
+    def _server_thread(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self.server_future = loop.create_future()
+
+        async def inner():
+            authenticator = Authenticator({
+                'test': {
+                    'secret': 'secret',
+                    'subchans': ['test-chan'],
+                    'pubchans': ['test-chan'],
+                    'owner': 'some-owner',
+                }
+            })
+
+            self.server = Server(authenticator, '127.0.0.1', 20000)
+
+            self.log.debug('Starting server')
+            future = asyncio.ensure_future(self.server.serve_forever())
+
+            self.log.debug('Awaiting test teardown')
+            await self.server_future
+
+            self.log.debug('Stopping test server')
+            future.cancel()
+            await future
+
+        loop.run_until_complete(inner())
+
+    def setUp(self):
+        self.server_thread = threading.Thread(
+            target=self._server_thread,
+        )
+        self.server_thread.start()
+
+    def test_subscribe_and_publish(self):
+        c = Client('127.0.0.1', 20000, 'test', 'secret')
+        c.subscribe('test-chan')
+        c._subscribe()
+        c.publish('test-chan', b'data')
+        opcode, data = c._read_message()
+        assert opcode == 3
+        assert readpublish(data) == ('test', 'test-chan', b'data')
+        self.log.debug('Stopping client')
+        c.stop()
+        self.log.debug('Closing client')
+        c.close()
+
+    def tearDown(self):
+        self.log.debug('Cancelling future')
+        self.server_future.set_result(None)
+        self.log.debug('Waiting')
+        self.server_thread.join()
+        assert len(self.server.connections) == 0, 'Connection left dangling'

--- a/hpfeeds/tests/test_client_integration.py
+++ b/hpfeeds/tests/test_client_integration.py
@@ -5,7 +5,7 @@ import unittest
 
 from hpfeeds.broker.auth.memory import Authenticator
 from hpfeeds.broker.server import Server
-from hpfeeds.client import Client
+from hpfeeds import client
 from hpfeeds.protocol import readpublish
 
 
@@ -49,7 +49,7 @@ class TestClientIntegration(unittest.TestCase):
         self.server_thread.start()
 
     def test_subscribe_and_publish(self):
-        c = Client('127.0.0.1', 20000, 'test', 'secret')
+        c = client.new('127.0.0.1', 20000, 'test', 'secret')
         c.subscribe('test-chan')
         c._subscribe()
         c.publish('test-chan', b'data')

--- a/hpfeeds/tests/test_protocol.py
+++ b/hpfeeds/tests/test_protocol.py
@@ -67,12 +67,13 @@ class TestUnpacker(unittest.TestCase):
 
     def test_unpack_at_max_message_size_unicode_1(self):
         unpacker = Unpacker()
-        unpacker.feed(msgpublish(b'b', b'a', '\u2603'.encode('utf-8') * 349524))
+        data = msgpublish(b'b', b'a', '\u2603'.encode('utf-8') * 349524)
+        unpacker.feed(data)
         packets = list(iter(unpacker))
         assert len(unpacker.buf) == 0
         assert packets[0][0] == 3
         assert len(packets[0][1]) == (1024 ** 2)
-        #assert packets[0][1].endswith(b'a' * 349525)
+        # assert packets[0][1].endswith(b'a' * 349525)
 
     def test_unpack_at_max_message_size_unicode_2(self):
         unpacker = Unpacker()
@@ -81,7 +82,7 @@ class TestUnpacker(unittest.TestCase):
         assert len(unpacker.buf) == 0
         assert packets[0][0] == 3
         assert len(packets[0][1]) == (1024 ** 2)
-        #assert packets[0][1].endswith(b'a' * 349525)
+        # assert packets[0][1].endswith(b'a' * 349525)
 
     def test_unpack_at_max_message_size(self):
         unpacker = Unpacker()
@@ -98,8 +99,8 @@ class TestUnpacker(unittest.TestCase):
         packets = [next(iter(unpacker))]
         assert len(unpacker.buf) == 1024
         assert packets[0][0] == 3
-        #assert len(packets[0][1]) == (1024 ** 2)
-        #assert packets[0][1].endswith(b'a' * 1048574)
+        # assert len(packets[0][1]) == (1024 ** 2)
+        # assert packets[0][1].endswith(b'a' * 1048574)
 
     def test_unpack_1(self):
         unpacker = Unpacker()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
 flake8==3.5.0
--e git+git@github.com:Jc2k/hpfeeds3@43a0437a45032b519a2b7bd15599b46cada23223#egg=hpfeeds3
 idna==2.6
 mccabe==0.6.1
 pluggy==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,21 @@
-prometheus_client
-aiorun
+aiomock==0.1.0
+aiorun==2018.3.1
+attrs==17.3.0
+certifi==2018.1.18
+chardet==3.0.4
+codecov==2.0.15
+coverage==4.5.1
+flake8==3.5.0
+-e git+git@github.com:Jc2k/hpfeeds3@43a0437a45032b519a2b7bd15599b46cada23223#egg=hpfeeds3
+idna==2.6
+mccabe==0.6.1
+pluggy==0.6.0
+prometheus-client==0.2.0
+py==1.5.2
+pycodestyle==2.3.1
+pyflakes==1.6.0
+pytest==3.3.1
+pytest-cov==2.5.1
+requests==2.18.4
+six==1.11.0
+urllib3==1.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+prometheus_client
+aiorun

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,9 @@ chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
 flake8==3.5.0
+flake8-isort==2.5
 idna==2.6
+isort==4.3.4
 mccabe==0.6.1
 pluggy==0.6.0
 prometheus-client==0.2.0
@@ -17,4 +19,5 @@ pytest==3.3.1
 pytest-cov==2.5.1
 requests==2.18.4
 six==1.11.0
+testfixtures==6.0.0
 urllib3==1.22

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,14 @@
+[wheel]
+universal = 1
+
+[flake8]
+max-line-length = 150
+max-complexity = 11
+
+[zest.releaser]
+create-wheel = yes
+
+[isort]
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+multi_line_output=3
+include_trailing_comma=True


### PR DESCRIPTION
This PR ports the broker to asyncio.

This also fixes a longstanding issue with the existing gevent broker where you have large events and lots of publishers. The use of`sock.sendall()` in the original design led to large packets being split into multiple `send()` calls. With a busy broker and lots of publishers this invariably causes events to be inserted in the middle of other events, causing all your clients to at best disconnect but actually with old py2 clients you see infinite reading (with no events processed) or infinite reconnecting. This kind of thing can be hard to debug with gevent as the 'asynchronousicity' of your code is masked. This is essentially a thread-safe-ness issue, because greenlets **really** are just co-operative threads. 

This also adds prometheus compatible metrics scraping.